### PR TITLE
Fix page title

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -12,7 +12,7 @@ const providerPaths = result.map((provider) => `/provider/${provider.miner_id}`)
 // See https://observablehq.com/framework/config for documentation.
 export default {
   // The app’s title; used in the sidebar and webpage titles.
-  title: 'spark-dash',
+  title: 'Spark Dashboard',
 
   // The pages and sections in the sidebar. If you don’t specify this option,
   // all pages will be listed in alphabetical order. Listing pages explicitly


### PR DESCRIPTION
"spark-dash" isn't something we should expose

<img width="331" alt="Screenshot 2025-02-13 at 11 33 30" src="https://github.com/user-attachments/assets/1af4f646-2d58-475b-af7e-4c6ebe3ad538" />
