### PR TITLE
chore: Change TTFB chart tick from day to month

### DIFF
--- a/src/data/spark-miner-rsr-summaries.json.js
+++ b/src/data/spark-miner-rsr-summaries.json.js
@@ -3,7 +3,7 @@ import { getDateXDaysAgo } from '../utils/date-utils.js'
 
 const summaries = {}
 
-for (let i = 201; i >= 1; i--) {
+for (let i = 100; i >= 1; i--) {
   const dayString = getDateXDaysAgo(i)
   summaries[dayString] = await jsonFetcher(
     `https://stats.filspark.com/miners/retrieval-success-rate/summary?from=${dayString}&to=${dayString}`,

--- a/src/index.md
+++ b/src/index.md
@@ -282,8 +282,7 @@ const tidy = clone(SparkRetrievalResultCodes).flatMap(({ day, rates }) => {
     <div class="card">
         ${Plot.plot({
         title: 'Time to First Byte (ms)',
-        // TODO: Change tick to month once we have more data
-        x: { type: 'utc', ticks: 'day' },
+        x: { type: 'utc', ticks: 'month' },
         y: { grid: true, zero: true},
         marks: [
           Plot.lineY(SparkRetrievalTimes, {

--- a/src/provider/[provider].md
+++ b/src/provider/[provider].md
@@ -42,8 +42,7 @@ const end = view(Inputs.date({ label: 'End', value: getDateXDaysAgo(1) }))
     <div class="card">
       ${Plot.plot({
       title: 'Time to First Byte (ms)',
-      // TODO: Change tick to month once we have more data
-      x: { type: 'utc', ticks: 'day' },
+      x: { type: 'utc', ticks: 'month' },
       y: { grid: true, zero: true },
       marks: [
         Plot.lineY(ttfbData, {


### PR DESCRIPTION
With the introduction of the TTFB stat, we initially set the Spark TTFB chart to display data by day due to the limited dataset. Now that we've gathered a substantial amount of data, the charts are starting to look like this:

<img width="707" alt="Screenshot 2025-03-03 at 14 57 47" src="https://github.com/user-attachments/assets/b60d116d-ba6f-4c5c-a672-af0c1dbe4df0" />


This PR changes chart tick back from `day` to `month` making charts look like this in return: 

<img width="700" alt="Screenshot 2025-03-03 at 15 01 50" src="https://github.com/user-attachments/assets/649ed6fe-5dda-404b-9f43-16ad6d96282d" />
