### PR TITLE
feat: add tooltip support for exact X & Y values on hover

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/components/histogram.js
+++ b/src/components/histogram.js
@@ -44,9 +44,9 @@ export function Histogram(events, { width, title, thresholds }) {
           format: {
             threshold: (v) => `Range: ${v}%`,
             count: (v) => `Count: ${v} miners`,
-            type: true
-          }
-        }
+            type: true,
+          },
+        },
       }),
     ],
     y: { grid: true },

--- a/src/components/histogram.js
+++ b/src/components/histogram.js
@@ -40,6 +40,13 @@ export function Histogram(events, { width, title, thresholds }) {
         y: 'count',
         x: 'type',
         fill: 'type',
+        tip: {
+          format: {
+            threshold: (v) => `Range: ${v}%`,
+            count: (v) => `Count: ${v} miners`,
+            type: true
+          }
+        }
       }),
     ],
     y: { grid: true },

--- a/src/components/line-graph.js
+++ b/src/components/line-graph.js
@@ -27,7 +27,7 @@ export function LineGraph(events, { width, height, title, start, end } = {}) {
       month: 'short',
       day: 'numeric',
     })
-  const formatPercent = (v) => (v ? `${(v * 100).toFixed(2)}%` : 'N/A')
+  const formatPercent = (v) => (v ? `${v.toFixed(2)}%` : 'N/A')
 
   return Plot.plot({
     title,

--- a/src/components/line-graph.js
+++ b/src/components/line-graph.js
@@ -21,12 +21,13 @@ export function LineGraph(events, { width, height, title, start, end } = {}) {
   ]
 
   // Format functions for tooltip values
-  const formatDate = (d) => new Date(d).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric'
-  })
-  const formatPercent = (v) => v ? `${(v * 100).toFixed(2)}%` : 'N/A'
+  const formatDate = (d) =>
+    new Date(d).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+  const formatPercent = (v) => (v ? `${(v * 100).toFixed(2)}%` : 'N/A')
 
   return Plot.plot({
     title,
@@ -45,9 +46,9 @@ export function LineGraph(events, { width, height, title, start, end } = {}) {
           format: {
             x: formatDate,
             y: formatPercent,
-            type: true
-          }
-        }
+            type: true,
+          },
+        },
       }),
       Plot.lineY(combinedData, {
         x: 'day',
@@ -58,9 +59,9 @@ export function LineGraph(events, { width, height, title, start, end } = {}) {
           format: {
             x: formatDate,
             y: formatPercent,
-            type: true
-          }
-        }
+            type: true,
+          },
+        },
       }),
     ],
   })

--- a/src/components/line-graph.js
+++ b/src/components/line-graph.js
@@ -20,6 +20,14 @@ export function LineGraph(events, { width, height, title, start, end } = {}) {
     })),
   ]
 
+  // Format functions for tooltip values
+  const formatDate = (d) => new Date(d).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  })
+  const formatPercent = (v) => v ? `${(v * 100).toFixed(2)}%` : 'N/A'
+
   return Plot.plot({
     title,
     width,
@@ -33,12 +41,26 @@ export function LineGraph(events, { width, height, title, start, end } = {}) {
         y: 'success_rate',
         stroke: 'type',
         curve: 'linear',
+        tip: {
+          format: {
+            x: formatDate,
+            y: formatPercent,
+            type: true
+          }
+        }
       }),
       Plot.lineY(combinedData, {
         x: 'day',
         y: 'success_rate_http',
         stroke: 'type',
         curve: 'linear',
+        tip: {
+          format: {
+            x: formatDate,
+            y: formatPercent,
+            type: true
+          }
+        }
       }),
     ],
   })

--- a/src/index.md
+++ b/src/index.md
@@ -311,7 +311,7 @@ const tidy = clone(SparkRetrievalResultCodes).flatMap(({ day, rates }) => {
                   month: 'short',
                   day: 'numeric'
                 }),
-                y: v => `${v.toFixed(2)}%`,
+                y: v => v.toFixed(2),
                 code: true
               }
             }

--- a/src/index.md
+++ b/src/index.md
@@ -186,7 +186,7 @@ const percentiles = Object.entries(SparkMinerRsrSummaries).flatMap(
     ${Plot.plot({
       title: '# of Filecoin SPs with Spark Retrieval Success Rate above x%',
       x: { label: null },
-      y: { grid: true, label: null },
+      y: { grid: true, label: '# SPs above x%' },
       color: {
         scheme: "Paired",
         legend: "swatches"

--- a/src/index.md
+++ b/src/index.md
@@ -311,7 +311,7 @@ const tidy = clone(SparkRetrievalResultCodes).flatMap(({ day, rates }) => {
                   month: 'short',
                   day: 'numeric'
                 }),
-                y: v => `${(v * 100).toFixed(2)}%`,
+                y: v => `${v.toFixed(2)}%`,
                 code: true
               }
             }

--- a/src/index.md
+++ b/src/index.md
@@ -141,7 +141,7 @@ const percentiles = Object.entries(SparkMinerRsrSummaries).flatMap(
       ${Plot.plot({
       title: '# of Filecoin SPs with a non-zero Spark Retrieval Success Rate',
       x: { label: null },
-      y: { grid: true, label: null },
+      y: { grid: true, label: '# Non-Zero SPs' },
       color: { legend: true },
       marks: [
         Plot.ruleY([0]),

--- a/src/index.md
+++ b/src/index.md
@@ -150,12 +150,34 @@ const percentiles = Object.entries(SparkMinerRsrSummaries).flatMap(
           y: 'count_succes_rate',
           stroke: "type",
           curve: 'catmull-rom',
+          tip: {
+            format: {
+              x: d => new Date(d).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric'
+              }),
+              y: v => `${v} SPs`,
+              type: true
+            }
+          }
         }),
         Plot.line(nonZeroMinersOverTime, {
           x: 'day',
           y: 'count_succes_rate_http',
           stroke: "type",
           curve: 'catmull-rom',
+          tip: {
+            format: {
+              x: d => new Date(d).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric'
+              }),
+              y: v => v ? `${v} SPs` : 'N/A',
+              type: true
+            }
+          }
         })
       ]
     })}
@@ -175,7 +197,18 @@ const percentiles = Object.entries(SparkMinerRsrSummaries).flatMap(
           x: 'day',
           y: 'count_succes_rate',
           stroke: 'label',
-          curve: 'catmull-rom'
+          curve: 'catmull-rom',
+          tip: {
+            format: {
+              x: d => new Date(d).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric'
+              }),
+              y: v => `${v} SPs`,
+              label: true
+            }
+          }
         })
       ]
     })}
@@ -270,7 +303,18 @@ const tidy = clone(SparkRetrievalResultCodes).flatMap(({ day, rates }) => {
             fill: "code",
             offset: "normalize",
             sort: {color: null, x: "-y" },
-            interval: 'day'
+            interval: 'day',
+            tip: {
+              format: {
+                x: d => new Date(d).toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric'
+                }),
+                y: v => `${(v * 100).toFixed(2)}%`,
+                code: true
+              }
+            }
           })
         ]
       })}
@@ -289,6 +333,16 @@ const tidy = clone(SparkRetrievalResultCodes).flatMap(({ day, rates }) => {
             x: 'day',
             y: 'ttfb_ms',
             stroke: "#FFBD3F",
+            tip: {
+              format: {
+                x: d => new Date(d).toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric'
+                }),
+                y: v => `${v.toFixed(2)} ms`
+              }
+            }
           })
         ]
       })}

--- a/src/index.md
+++ b/src/index.md
@@ -145,7 +145,7 @@ const percentiles = Object.entries(SparkMinerRsrSummaries).flatMap(
       color: { legend: true },
       marks: [
         Plot.ruleY([0]),
-        Plot.line(nonZeroMinersOverTime, {
+        Plot.lineY(nonZeroMinersOverTime, {
           x: 'day',
           y: 'count_succes_rate',
           stroke: "type",
@@ -162,7 +162,7 @@ const percentiles = Object.entries(SparkMinerRsrSummaries).flatMap(
             }
           }
         }),
-        Plot.line(nonZeroMinersOverTime, {
+        Plot.lineY(nonZeroMinersOverTime, {
           x: 'day',
           y: 'count_succes_rate_http',
           stroke: "type",

--- a/src/index.md
+++ b/src/index.md
@@ -327,7 +327,7 @@ const tidy = clone(SparkRetrievalResultCodes).flatMap(({ day, rates }) => {
         ${Plot.plot({
         title: 'Time to First Byte (ms)',
         x: { type: 'utc', ticks: 'month' },
-        y: { grid: true, zero: true},
+        y: { grid: true, zero: true, label: 'ttfb (ms)' },
         marks: [
           Plot.lineY(SparkRetrievalTimes, {
             x: 'day',
@@ -340,7 +340,7 @@ const tidy = clone(SparkRetrievalResultCodes).flatMap(({ day, rates }) => {
                   month: 'short',
                   day: 'numeric'
                 }),
-                y: v => `${v.toFixed(2)} ms`
+                y: v => v.toFixed(0)
               }
             }
           })

--- a/src/index.md
+++ b/src/index.md
@@ -294,7 +294,7 @@ const tidy = clone(SparkRetrievalResultCodes).flatMap(({ day, rates }) => {
         color: {
           scheme: "Accent",
           legend: "swatches",
-          label: "Codes"
+          label: "code"
         },
         marks: [
           Plot.rectY(tidy, {


### PR DESCRIPTION
# Add Tooltips to All Dashboard Graphs

## Description
This PR adds hover tooltips to all graphs in the Spark Dashboard to show exact values when users hover over data points. This enhancement improves the dashboard's usability by allowing users to see precise values without having to estimate from the axes.

## Changes Made
Added tooltips with formatted values to:

1. **Line Graphs (Overall Spark RSR)**
   - Shows exact date (MMM DD, YYYY format)
   - Shows precise success rate percentage (2 decimal places)
   - Indicates type (HTTP or Graphsync / HTTP only)

2. **Histograms (Spark Miner RSR)**
   - Shows range of each bin
   - Displays count of miners in each bin
   - Shows type of measurement

3. **Time To First Byte (TTFB) Graph**
   - Shows formatted date
   - Displays precise TTFB in milliseconds (2 decimal places)

4. **Retrieval Result Codes Graph**
   - Shows formatted date
   - Displays percentage for each code type
   - Shows code category

5. **RSR Buckets Over Time Graphs**
   - Shows formatted date
   - Displays exact count of Storage Providers
   - Shows threshold or type information
   

## Implementation Details
- Used Observable Plot's native tooltip system for optimal performance
- Implemented consistent date formatting across all graphs
- Added proper handling for null/undefined values (showing "N/A")
- Maintained color coding and type information in tooltips where relevant

## Screenshots
![image](https://github.com/user-attachments/assets/fdb070b1-bc82-423f-bc3f-9b57938a14ce)
![image](https://github.com/user-attachments/assets/4941ae4c-8d69-4162-a0de-1d46d60cf31b)
![image](https://github.com/user-attachments/assets/b2091e36-9709-4e4d-a7b8-fe11087db228)
![image](https://github.com/user-attachments/assets/3444aec2-5d5c-4738-8e56-d9122ad0f453)
![image](https://github.com/user-attachments/assets/e5f89450-cae3-4e41-9ef3-2172b1ec24db)
![image](https://github.com/user-attachments/assets/8f80ea82-71a4-452a-ada3-c8cbdf00a03f)
![image](https://github.com/user-attachments/assets/85251d39-3942-4f96-a2bd-bfe82d09bf31)
![image](https://github.com/user-attachments/assets/2aac8046-daf6-40ea-9ac4-a8bcffb66917)


Fixes #11 
