### PR TITLE
fix: show per-miner RSR from zero

### DIFF
--- a/src/components/line-graph.js
+++ b/src/components/line-graph.js
@@ -1,6 +1,9 @@
 import * as Plot from 'npm:@observablehq/plot'
 
-export function LineGraph(events, { width, height, title, start, end, fromZero } = {}) {
+export function LineGraph(
+  events,
+  { width, height, title, start, end, fromZero } = {},
+) {
   const startDate = new Date(start)
   const endDate = new Date(end)
   const filteredEvents = events.filter((event) => {
@@ -25,7 +28,13 @@ export function LineGraph(events, { width, height, title, start, end, fromZero }
     width,
     height,
     x: { type: 'utc', ticks: 'month', label: null },
-    y: { grid: true, inset: 10, label: 'RSR (%)', percent: true, zero: fromZero },
+    y: {
+      grid: true,
+      inset: 10,
+      label: 'RSR (%)',
+      percent: true,
+      zero: fromZero,
+    },
     color: { legend: true },
     marks: [
       Plot.lineY(combinedData, {

--- a/src/components/line-graph.js
+++ b/src/components/line-graph.js
@@ -1,6 +1,6 @@
 import * as Plot from 'npm:@observablehq/plot'
 
-export function LineGraph(events, { width, height, title, start, end } = {}) {
+export function LineGraph(events, { width, height, title, start, end, fromZero } = {}) {
   const startDate = new Date(start)
   const endDate = new Date(end)
   const filteredEvents = events.filter((event) => {
@@ -25,7 +25,7 @@ export function LineGraph(events, { width, height, title, start, end } = {}) {
     width,
     height,
     x: { type: 'utc', ticks: 'month', label: null },
-    y: { grid: true, inset: 10, label: 'RSR (%)', percent: true },
+    y: { grid: true, inset: 10, label: 'RSR (%)', percent: true, zero: fromZero },
     color: { legend: true },
     marks: [
       Plot.lineY(combinedData, {

--- a/src/provider/[provider].md
+++ b/src/provider/[provider].md
@@ -33,7 +33,7 @@ const end = view(Inputs.date({ label: 'End', value: getDateXDaysAgo(1) }))
     <h4>Storage Provider Spark RSR Summary</h4>
     <body>This section shows the storage provider Spark Retrieval Success Rate Score summary.</body>
     <div class="card">${
-      resize((width) => LineGraph(rsrData, {width, title: "Retrieval Success Rate", start, end }))
+      resize((width) => LineGraph(rsrData, {width, title: "Retrieval Success Rate", start, end, fromZero: true }))
     }</div>
   </div>
   <div>


### PR DESCRIPTION
Configure the y-axis to start from zero. This way the chart emphasises the overal RSR score (e.g. 76%) rather than fluctations over time (60-80%).

Before:

<img width="716" alt="Screenshot 2025-03-10 at 11 40 15" src="https://github.com/user-attachments/assets/bf557d12-4b1d-45b2-916a-4fc3e62c1742" />

After:

<img width="696" alt="Screenshot 2025-03-10 at 11 48 19" src="https://github.com/user-attachments/assets/4b8fd6c6-7740-4eec-9639-7b2b6e32ef2c" />
