### PR TITLE
feat: show RSR from zero in all charts

### DIFF
--- a/src/components/line-graph.js
+++ b/src/components/line-graph.js
@@ -33,7 +33,7 @@ export function LineGraph(
       inset: 10,
       label: 'RSR (%)',
       percent: true,
-      zero: fromZero,
+      zero: fromZero ?? true,
     },
     color: { legend: true },
     marks: [

--- a/src/provider/[provider].md
+++ b/src/provider/[provider].md
@@ -33,7 +33,7 @@ const end = view(Inputs.date({ label: 'End', value: getDateXDaysAgo(1) }))
     <h4>Storage Provider Spark RSR Summary</h4>
     <body>This section shows the storage provider Spark Retrieval Success Rate Score summary.</body>
     <div class="card">${
-      resize((width) => LineGraph(rsrData, {width, title: "Retrieval Success Rate", start, end, fromZero: true }))
+      resize((width) => LineGraph(rsrData, {width, title: "Retrieval Success Rate", start, end }))
     }</div>
   </div>
   <div>


### PR DESCRIPTION
Configure the y-axis to start from zero in all charts showing RSR.  This way the charts emphasise the overal RSR score (e.g. 76%) rather than fluctations over time (e.g. 60-80%).


This is a follow-up for https://github.com/CheckerNetwork/spark-dashboard/pull/32#pullrequestreview-2670524328

Before:

<img width="1411" alt="Screenshot 2025-03-11 at 13 44 17" src="https://github.com/user-attachments/assets/3a0d3e26-a083-4df4-8121-2aa54144b2a6" />

After:

<img width="1397" alt="Screenshot 2025-03-11 at 13 44 09" src="https://github.com/user-attachments/assets/31a97671-9a88-4936-8c86-0b2c607522b7" />
