### PR TITLE
remove totals from stats tables

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -60,7 +60,7 @@ const tidySparkClientRates = SparkClientRates.sort(
   return {
     ...record,
     success_rate: `${(record.success_rate * 100).toFixed(2)}%`,
-    success_rate_http: `${(record.success_rate_http * 100).toFixed(2)}%`
+    success_rate_http: `${(record.success_rate_http * 100).toFixed(2)}%`,
   }
 })
 ```

--- a/src/index.md
+++ b/src/index.md
@@ -43,6 +43,8 @@ const tidySparkMinerRates = SparkMinerRates.sort(
   (recordA, recordB) => recordB.success_rate - recordA.success_rate,
 ).map((record) => {
   const { ttfb_ms } = sparkMinerRetrievalTimingsMap[record.miner_id] ?? {}
+  delete record.successful
+  delete record.successful_http
   return {
     ...record,
     ttfb_ms,
@@ -52,11 +54,15 @@ const tidySparkMinerRates = SparkMinerRates.sort(
 })
 const tidySparkClientRates = SparkClientRates.sort(
   (recordA, recordB) => recordB.success_rate - recordA.success_rate,
-).map((record) => ({
-  ...record,
-  success_rate: `${(record.success_rate * 100).toFixed(2)}%`,
-  success_rate_http: `${(record.success_rate_http * 100).toFixed(2)}%`,
-}))
+).map((record) => {
+  delete record.successful
+  delete record.successful_http
+  return {
+    ...record,
+    success_rate: `${(record.success_rate * 100).toFixed(2)}%`,
+    success_rate_http: `${(record.success_rate_http * 100).toFixed(2)}%`
+  }
+})
 ```
 
 <div class="hero">


### PR DESCRIPTION
Aside from the total number of requests, the total number of successful requests, successful HTTP requests and so on, aren't meaningful to humans - they want to see the ratios only.

After:

<img width="1239" alt="Screenshot 2025-03-19 at 09 04 01" src="https://github.com/user-attachments/assets/ed2e14e1-0111-4d43-bcbf-2db320b7952a" />

Before:

<img width="1230" alt="Screenshot 2025-03-19 at 09 03 38" src="https://github.com/user-attachments/assets/b78670f4-fc23-45ac-a953-bace27a1bff6" />
