### PR TITLE
ci: Slack alert when Cloudflare Page deployment fails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,3 +44,22 @@ jobs:
           projectName: spark-dashboard # Replace with your Cloudflare Pages project name
           directory: ./dist # Replace with your output directory after build
 
+      - if: failure()
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "alerts",
+              "text": "Deployment of `${{ github.event.repository.name }}` failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: *<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Deployment of `${{ github.event.repository.name }}` failed>*"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
Yesterday, the scheduled build failed and nobody noticed.

https://github.com/CheckerNetwork/spark-dashboard/actions/runs/13932406117
<img width="1279" alt="Screenshot 2025-03-19 at 14 23 45" src="https://github.com/user-attachments/assets/12015cfd-74db-473e-aa36-21d30c4c2116" />

In the morning, I was confused why the dashboard does not show RSR for Curio operators - it was because we did not rebuild the dashboard with new data.

This pull request adds a Slack alert for failed deployments.

I just copy&pasted code we already have in other repos.