### PR TITLE
chore: rebuild the dashboard at 04:00 UTC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   schedule:
-    - cron: '0 20 * * *'
+    - cron: '0 4 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The dashboard shows data with one day granularity. New data point is added by spark-evaluate & spark-stats repositories every midnight (0:00 UTC).

The current schedule of rebuilding the dashboard at 20:00 UTC meant that the dashboard was missing the latest data for most of the day.

This commit changes the schedule to run the job at 04:00 UTC. The buffer of four hours after midnight before running the job should be enough to accommodate any delays in the pipelines updating daily stats.
