### PR TITLE
Fix HEAD success count in non-zero miners over time

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -205,6 +205,23 @@ const percentiles = Object.entries(SparkMinerRsrSummaries).flatMap(
               type: true
             }
           }
+        }),
+        Plot.lineY(nonZeroMinersOverTime, {
+          x: 'day',
+          y: 'count_succes_rate_http_head',
+          stroke: "type",
+          curve: 'catmull-rom',
+          tip: {
+            format: {
+              x: d => new Date(d).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric'
+              }),
+              y: v => v ? `${v} SPs` : 'N/A',
+              type: true
+            }
+          }
         })
       ]
     })}


### PR DESCRIPTION
Adds the missing yellow line here:

<img width="599" alt="Screenshot 2025-03-24 at 10 56 07" src="https://github.com/user-attachments/assets/97a90f0a-cde6-4bbd-86c8-f6440baca988" />
