### PR TITLE
feat: add allocator rsr scores

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -60,5 +60,5 @@ export default {
   // linkify: true, // convert URLs in Markdown to links
   // typographer: false, // smart quotes and other typographic improvements
   // cleanUrls: true, // drop .html from URLs
-  dynamicPaths: [...providerPaths, ...clientPaths,...allocatorPaths],
+  dynamicPaths: [...providerPaths, ...clientPaths, ...allocatorPaths],
 }

--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -3,6 +3,7 @@ import { getDateXDaysAgo } from './src/utils/date-utils.js'
 
 const startProviders = '2024-04-07'
 const startClients = '2025-02-25'
+const startAllocators = '2025-03-26'
 const end = getDateXDaysAgo(1)
 
 const providersSummary = await jsonFetcher(
@@ -11,11 +12,17 @@ const providersSummary = await jsonFetcher(
 const clientsSummary = await jsonFetcher(
   `https://stats.filspark.com/clients/retrieval-success-rate/summary?from=${startClients}&to=${end}`,
 )
+const allocatorsSummary = await jsonFetcher(
+  `https://stats.filspark.com/allocators/retrieval-success-rate/summary?from=${startAllocators}&to=${end}`,
+)
 const providerPaths = providersSummary.map(
   (provider) => `/provider/${provider.miner_id}`,
 )
 const clientPaths = clientsSummary.map(
   (client) => `/client/${client.client_id}`,
+)
+const allocatorPaths = allocatorsSummary.map(
+  (allocator) => `/allocator/${allocator.allocator_id}`,
 )
 // See https://observablehq.com/framework/config for documentation.
 export default {
@@ -53,5 +60,5 @@ export default {
   // linkify: true, // convert URLs in Markdown to links
   // typographer: false, // smart quotes and other typographic improvements
   // cleanUrls: true, // drop .html from URLs
-  dynamicPaths: [...providerPaths, ...clientPaths],
+  dynamicPaths: [...providerPaths, ...clientPaths,...allocatorPaths],
 }

--- a/src/allocator/[allocator].md
+++ b/src/allocator/[allocator].md
@@ -1,0 +1,86 @@
+---
+toc: false
+title: Storage Allocator Summary
+---
+
+```js
+import { LineGraph } from '../components/line-graph.js'
+import { getDateXDaysAgo } from '../utils/date-utils.js'
+
+const data = FileAttachment(
+  `../data/${observable.params.allocator}-spark-allocator-rsr-summary.json`,
+).json()
+```
+
+<div class="hero">
+  <body><a href="/"><img src="../media/spark-logomark-blue-with-bbox.png" alt="Spark Logo" width="300" /></a><body>
+    <h2>Dashboard Beta</h2>
+    <body><a href="https://filspark.com/dashboard" target="_blank" rel="noopener noreferrer">(Click here for Legacy Spark Grafana Dashboard)</a><body>
+</div>
+
+<h4>Storage Allocator Spark RSR Summary</h4>
+<body>This section shows the storage allocator Spark Retrieval Success Rate Score summary. You can adjust the date range. Records start on the 25th February 2025.</body>
+
+```js
+const startDate = getDateXDaysAgo(180)
+const minStartDate = '2025-02-25'
+const start = view(
+  Inputs.date({
+    label: 'Start',
+    value:
+      new Date(startDate) >= new Date(minStartDate) ? startDate : minStartDate,
+  }),
+)
+const end = view(Inputs.date({ label: 'End', value: getDateXDaysAgo(1) }))
+```
+
+<h3>Stats for ${observable.params.allocator}</h3>
+
+<div class="grid grid-cols" style="grid-auto-rows: 500px;">
+  <div class="card">${
+    resize((width) => LineGraph(data, {width, title: "Retrieval Success Rate", start, end }))
+  }</div>
+</div>
+
+<style>
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-family: var(--sans-serif);
+  margin: 4rem 0 8rem;
+  text-wrap: balance;
+  text-align: center;
+}
+
+.hero h1 {
+  margin: 1rem 0;
+  padding: 1rem 0;
+  max-width: none;
+  font-size: 14vw;
+  font-weight: 900;
+  line-height: 1;
+  background: linear-gradient(30deg, var(--theme-foreground-focus), currentColor);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.hero h2 {
+  margin: 0;
+  max-width: 34em;
+  font-size: 20px;
+  font-style: initial;
+  font-weight: 500;
+  line-height: 1.5;
+  color: var(--theme-foreground-muted);
+}
+
+@media (min-width: 640px) {
+  .hero h1 {
+    font-size: 90px;
+  }
+}
+
+</style>

--- a/src/data/[allocator]-spark-allocator-rsr-summary.json.js
+++ b/src/data/[allocator]-spark-allocator-rsr-summary.json.js
@@ -8,7 +8,7 @@ const {
 } = parseArgs({
   options: { allocator: { type: 'string' } },
 })
-const start = '2025-02-25'
+const start = '2025-03-26'
 const end = getDateXDaysAgo(1)
 const summary = await pRetry(
   () =>

--- a/src/data/[allocator]-spark-allocator-rsr-summary.json.js
+++ b/src/data/[allocator]-spark-allocator-rsr-summary.json.js
@@ -1,0 +1,20 @@
+import pRetry from 'p-retry'
+import { jsonFetcher } from './json-fetcher.js'
+import { getDateXDaysAgo } from '../utils/date-utils.js'
+import { parseArgs } from 'node:util'
+
+const {
+  values: { allocator },
+} = parseArgs({
+  options: { allocator: { type: 'string' } },
+})
+const start = '2025-02-25'
+const end = getDateXDaysAgo(1)
+const summary = await pRetry(
+  () =>
+    jsonFetcher(
+      `https://stats.filspark.com/allocator/${allocator}/retrieval-success-rate/summary?from=${start}&to=${end}`,
+    ),
+  { retries: 3 },
+)
+process.stdout.write(JSON.stringify(summary))

--- a/src/data/spark-allocators-rsr.json.js
+++ b/src/data/spark-allocators-rsr.json.js
@@ -1,0 +1,10 @@
+import { jsonFetcher } from './json-fetcher.js'
+import { getDateXDaysAgo } from '../utils/date-utils.js'
+
+const from = getDateXDaysAgo(31)
+const to = getDateXDaysAgo(1)
+
+const output = await jsonFetcher(
+  `https://stats.filspark.com/allocators/retrieval-success-rate/summary?from=${from}&to=${to}`,
+)
+process.stdout.write(JSON.stringify(output))

--- a/src/index.md
+++ b/src/index.md
@@ -25,7 +25,9 @@ const SparkRetrievalTimes = FileAttachment(
   './data/spark-retrieval-timings.json',
 ).json()
 const SparkClientRates = FileAttachment('./data/spark-clients-rsr.json').json()
-const SparkAllocatorRates = FileAttachment('./data/spark-allocators-rsr.json').json()
+const SparkAllocatorRates = FileAttachment(
+  './data/spark-allocators-rsr.json',
+).json()
 ```
 
 ```js
@@ -459,7 +461,6 @@ const searchClientStats = view(
 
 <h4>Spark Allocator RSR Table</h4>
 <body>The following table shows the Spark RSR values calculated in aggregate for each Filecoin Storage Allocator over the past 30 days. Click on a allocator id to view stats about this storage allocator.</body>
-
 
 ```js
 const searchAllocatorStats = view(

--- a/src/index.md
+++ b/src/index.md
@@ -25,6 +25,7 @@ const SparkRetrievalTimes = FileAttachment(
   './data/spark-retrieval-timings.json',
 ).json()
 const SparkClientRates = FileAttachment('./data/spark-clients-rsr.json').json()
+const SparkAllocatorRates = FileAttachment('./data/spark-allocators-rsr.json').json()
 ```
 
 ```js
@@ -54,6 +55,17 @@ const tidySparkMinerRates = SparkMinerRates.sort(
   }
 })
 const tidySparkClientRates = SparkClientRates.sort(
+  (recordA, recordB) => recordB.success_rate - recordA.success_rate,
+).map((record) => {
+  delete record.successful
+  delete record.successful_http
+  return {
+    ...record,
+    success_rate: `${(record.success_rate * 100).toFixed(2)}%`,
+    success_rate_http: `${(record.success_rate_http * 100).toFixed(2)}%`,
+  }
+})
+const tidySparkAllocatorRates = SparkAllocatorRates.sort(
   (recordA, recordB) => recordB.success_rate - recordA.success_rate,
 ).map((record) => {
   delete record.successful
@@ -441,6 +453,24 @@ const searchClientStats = view(
 
 <div class="card" style="padding: 0;">
   ${Inputs.table(searchClientStats, {rows: 16, format: {client_id: id => htl.html`<a href=./client/${id} target=_blank>${id}</a>`}})}
+</div>
+
+<div class="divider"></div>
+
+<h4>Spark Allocator RSR Table</h4>
+<body>The following table shows the Spark RSR values calculated in aggregate for each Filecoin Storage Allocator over the past 30 days. Click on a allocator id to view stats about this storage allocator.</body>
+
+
+```js
+const searchAllocatorStats = view(
+  Inputs.search(tidySparkAllocatorRates, {
+    placeholder: 'Search Storage Allocators...',
+  }),
+)
+```
+
+<div class="card" style="padding: 0;">
+  ${Inputs.table(searchAllocatorStats, {rows: 16, format: {allocator_id: id => htl.html`<a href=./allocator/${id} target=_blank>${id}</a>`}})}
 </div>
 
 <style>


### PR DESCRIPTION
**CHANGELOG**

1. Add data fetcher for spark allocators rsr summary
2. Add stats table for client RSR scores similar to miner stats [table](https://github.com/CheckerNetwork/spark-dashboard/blob/main/src/index.md?plain=1#L329)
3. Per Allocator RSR visualization similar to miner RSR [visualization](https://github.com/CheckerNetwork/spark-dashboard/blob/main/src/provider/%5Bprovider%5D.md).

The visualization for the RSR scores for allocators closely resembles that of the miner RSR scores. 
The two major features added in this PR is the stats table for allocators and the per allocator stats visualization which appears once you click on one of the allocator ids in the stats table for allocators. 

Closes the two subtasks of https://github.com/CheckerNetwork/roadmap/issues/193  https://github.com/CheckerNetwork/roadmap/issues/216