### PR TITLE
ci: migrate to `cloudflare/wrangler-action@v3`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,12 +37,11 @@ jobs:
           API_TOKEN: ${{ secrets.API_TOKEN }}
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: spark-dashboard # Replace with your Cloudflare Pages project name
-          directory: ./dist # Replace with your output directory after build
+          command: pages deploy ./dist --project-name spark-dashboard
 
       - if: failure()
         uses: slackapi/slack-github-action@v2.0.0


### PR DESCRIPTION
`cloudflare/pages-action@v1` was deprecated in late 2024 and superseded by `cloudflare/wrangler-action@v3`

References:
- https://github.com/cloudflare/pages-action
- https://github.com/cloudflare/wrangler-action?tab=readme-ov-file#deploy-your-pages-site-production--preview
