### PR TITLE
fix: Table sorting

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -45,7 +45,6 @@ const nonZeroSparkMinerRates = SparkMinerRates.filter(
 const tidySparkMinerRates = SparkMinerRates.sort(
   (recordA, recordB) => recordB.success_rate - recordA.success_rate,
 ).map((record) => {
-  console.log(record)
   const { ttfb_ms } = sparkMinerRetrievalTimingsMap[record.miner_id] ?? {}
   delete record.successful
   delete record.successful_http

--- a/src/index.md
+++ b/src/index.md
@@ -45,15 +45,17 @@ const nonZeroSparkMinerRates = SparkMinerRates.filter(
 const tidySparkMinerRates = SparkMinerRates.sort(
   (recordA, recordB) => recordB.success_rate - recordA.success_rate,
 ).map((record) => {
+  console.log(record)
   const { ttfb_ms } = sparkMinerRetrievalTimingsMap[record.miner_id] ?? {}
   delete record.successful
   delete record.successful_http
   return {
     ...record,
     ttfb_ms,
-    success_rate: `${(record.success_rate * 100).toFixed(2)}%`,
-    success_rate_http: `${(record.success_rate_http * 100).toFixed(2)}%`,
-    success_rate_http_head: `${(record.success_rate_http_head * 100).toFixed(2)}%`,
+    total: BigInt(record.total),
+    success_rate: record.success_rate * 100,
+    success_rate_http: record.success_rate_http * 100,
+    success_rate_http_head: record.success_rate_http_head * 100,
   }
 })
 const tidySparkClientRates = SparkClientRates.sort(
@@ -63,8 +65,9 @@ const tidySparkClientRates = SparkClientRates.sort(
   delete record.successful_http
   return {
     ...record,
-    success_rate: `${(record.success_rate * 100).toFixed(2)}%`,
-    success_rate_http: `${(record.success_rate_http * 100).toFixed(2)}%`,
+    total: BigInt(record.total),
+    success_rate: record.success_rate * 100,
+    success_rate_http: record.success_rate_http * 100,
   }
 })
 const tidySparkAllocatorRates = SparkAllocatorRates.sort(
@@ -74,8 +77,9 @@ const tidySparkAllocatorRates = SparkAllocatorRates.sort(
   delete record.successful_http
   return {
     ...record,
-    success_rate: `${(record.success_rate * 100).toFixed(2)}%`,
-    success_rate_http: `${(record.success_rate_http * 100).toFixed(2)}%`,
+    total: BigInt(record.total),
+    success_rate: record.success_rate * 100,
+    success_rate_http: record.success_rate_http * 100,
   }
 })
 ```
@@ -436,8 +440,28 @@ const searchMinerStats = view(
 )
 ```
 
+```js
+const minerStatsTable = Inputs.table(searchMinerStats, {
+  rows: 16,
+  format: {
+    miner_id: (v) => htl.html`<a href=./provider/${v} target=_blank>${v}</a>`,
+    ttfb_ms: (v) => v?.toFixed(0),
+    success_rate: (v) => `${v?.toFixed(2)}%`,
+    success_rate_http: (v) => `${v?.toFixed(2)}%`,
+    success_rate_http_head: (v) => `${v?.toFixed(2)}%`,
+  },
+  sort: {
+    ttfb_ms: 'asc',
+    success_rate: 'desc',
+    success_rate_http: 'desc',
+    success_rate_http_head: 'desc',
+    total: 'desc',
+  },
+})
+```
+
 <div class="card" style="padding: 0;">
-  ${Inputs.table(searchMinerStats, {rows: 16, format: {miner_id: id => htl.html`<a href=./provider/${id} target=_blank>${id}</a>`}})}
+  ${minerStatsTable}
 </div>
 
 <div class="divider"></div>
@@ -453,8 +477,24 @@ const searchClientStats = view(
 )
 ```
 
+```js
+const clientStatsTable = Inputs.table(searchClientStats, {
+  rows: 16,
+  format: {
+    client_id: (v) => htl.html`<a href=./client/${v} target=_blank>${v}</a>`,
+    success_rate: (v) => `${v?.toFixed(2)}%`,
+    success_rate_http: (v) => `${v?.toFixed(2)}%`,
+  },
+  sort: {
+    success_rate: 'desc',
+    success_rate_http: 'desc',
+    total: 'desc',
+  },
+})
+```
+
 <div class="card" style="padding: 0;">
-  ${Inputs.table(searchClientStats, {rows: 16, format: {client_id: id => htl.html`<a href=./client/${id} target=_blank>${id}</a>`}})}
+  ${clientStatsTable}
 </div>
 
 <div class="divider"></div>
@@ -470,8 +510,25 @@ const searchAllocatorStats = view(
 )
 ```
 
+```js
+const allocatorStatsTable = Inputs.table(searchAllocatorStats, {
+  rows: 16,
+  format: {
+    allocator_id: (v) =>
+      htl.html`<a href=./allocator/${v} target=_blank>${v}</a>`,
+    success_rate: (v) => `${v?.toFixed(2)}%`,
+    success_rate_http: (v) => `${v?.toFixed(2)}%`,
+  },
+  sort: {
+    success_rate: 'desc',
+    success_rate_http: 'desc',
+    total: 'desc',
+  },
+})
+```
+
 <div class="card" style="padding: 0;">
-  ${Inputs.table(searchAllocatorStats, {rows: 16, format: {allocator_id: id => htl.html`<a href=./allocator/${id} target=_blank>${id}</a>`}})}
+  ${allocatorStatsTable}
 </div>
 
 <style>

--- a/src/index.md
+++ b/src/index.md
@@ -443,6 +443,7 @@ const searchMinerStats = view(
 const minerStatsTable = Inputs.table(searchMinerStats, {
   rows: 16,
   format: {
+    total: (v) => v?.toString(),
     miner_id: (v) => htl.html`<a href=./provider/${v} target=_blank>${v}</a>`,
     ttfb_ms: (v) => v?.toFixed(0),
     success_rate: (v) => `${v?.toFixed(2)}%`,
@@ -480,6 +481,7 @@ const searchClientStats = view(
 const clientStatsTable = Inputs.table(searchClientStats, {
   rows: 16,
   format: {
+    total: (v) => v?.toString(),
     client_id: (v) => htl.html`<a href=./client/${v} target=_blank>${v}</a>`,
     success_rate: (v) => `${v?.toFixed(2)}%`,
     success_rate_http: (v) => `${v?.toFixed(2)}%`,
@@ -513,6 +515,7 @@ const searchAllocatorStats = view(
 const allocatorStatsTable = Inputs.table(searchAllocatorStats, {
   rows: 16,
   format: {
+    total: (v) => v?.toString(),
     allocator_id: (v) =>
       htl.html`<a href=./allocator/${v} target=_blank>${v}</a>`,
     success_rate: (v) => `${v?.toFixed(2)}%`,

--- a/src/index.md
+++ b/src/index.md
@@ -51,7 +51,7 @@ const tidySparkMinerRates = SparkMinerRates.sort(
   return {
     ...record,
     ttfb_ms,
-    total: BigInt(record.total),
+    total: Number(record.total),
     success_rate: record.success_rate * 100,
     success_rate_http: record.success_rate_http * 100,
     success_rate_http_head: record.success_rate_http_head * 100,
@@ -64,7 +64,7 @@ const tidySparkClientRates = SparkClientRates.sort(
   delete record.successful_http
   return {
     ...record,
-    total: BigInt(record.total),
+    total: Number(record.total),
     success_rate: record.success_rate * 100,
     success_rate_http: record.success_rate_http * 100,
   }
@@ -76,7 +76,7 @@ const tidySparkAllocatorRates = SparkAllocatorRates.sort(
   delete record.successful_http
   return {
     ...record,
-    total: BigInt(record.total),
+    total: Number(record.total),
     success_rate: record.success_rate * 100,
     success_rate_http: record.success_rate_http * 100,
   }


### PR DESCRIPTION
This PR fixes sorting values inside dashboard tables. Fix is achieved by converting all sortable values to number and  keeping as numerical values,  formatting them inside of the `Inputs.table` element.

I have opted for `Number` instead of the `BigInt` for `total` value as we're using integers on the database level rather then big integers.

Closes #17 