### PR TITLE
ci: fix missing gh pages permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pages: write
+      id-token: write
       deployments: write
     environment: default
 


### PR DESCRIPTION
See https://github.com/actions/deploy-pages/tree/v4/?tab=readme-ov-file#usage