### PR TITLE
chore: Remove grafana dashboard link from all pages

### DIFF
--- a/src/allocator/[allocator].md
+++ b/src/allocator/[allocator].md
@@ -15,7 +15,6 @@ const data = FileAttachment(
 <div class="hero">
   <body><a href="/"><img src="../media/spark-logomark-blue-with-bbox.png" alt="Spark Logo" width="300" /></a><body>
     <h2>Dashboard Beta</h2>
-    <body><a href="https://filspark.com/dashboard" target="_blank" rel="noopener noreferrer">(Click here for Legacy Spark Grafana Dashboard)</a><body>
 </div>
 
 <h4>Storage Allocator Spark RSR Summary</h4>

--- a/src/client/[client].md
+++ b/src/client/[client].md
@@ -15,7 +15,6 @@ const data = FileAttachment(
 <div class="hero">
   <body><a href="/"><img src="../media/spark-logomark-blue-with-bbox.png" alt="Spark Logo" width="300" /></a><body>
     <h2>Dashboard Beta</h2>
-    <body><a href="https://filspark.com/dashboard" target="_blank" rel="noopener noreferrer">(Click here for Legacy Spark Grafana Dashboard)</a><body>
 </div>
 
 <h4>Storage Client Spark RSR Summary</h4>

--- a/src/provider/[provider].md
+++ b/src/provider/[provider].md
@@ -18,7 +18,6 @@ const ttfbData = FileAttachment(
 <div class="hero">
   <body><a href="/"><img src="../media/spark-logomark-blue-with-bbox.png" alt="Spark Logo" width="300" /></a><body>
     <h2>Dashboard Beta</h2>
-    <body><a href="https://filspark.com/dashboard" target="_blank" rel="noopener noreferrer">(Click here for Legacy Spark Grafana Dashboard)</a><body>
 </div>
 
 ```js


### PR DESCRIPTION
Removes link to grafana dashboard from client, allocator and provider pages.